### PR TITLE
Add position to jumplist before jumping in `common_sink`

### DIFF
--- a/lua/fzf_lsp.lua
+++ b/lua/fzf_lsp.lua
@@ -367,6 +367,9 @@ local function common_sink(infile, lines)
   action = action or "e"
 
   for _, loc in ipairs(locations) do
+    -- Add current position to jumplist
+    vim.cmd("normal! m'")
+
     local edit_infile = (
       (infile or fn.expand("%:~:.") == loc["filename"]) and
       (action == "e" or action == "edit")


### PR DESCRIPTION
`vim.fn.cursor` does not add the position under the cursor to the jumplist before moving.  Consequently, `common_sink`, which uses `vim.fn.cursor` to perform its jump, does not add the position under the cursor to the jumplist before moving.  This is undesirable as it differs from the behaviour of `vim.lsp.util.jump_to_location`, which is used in some circumstances when only a single location is present.  Additionally, I think it is fair to assume the user will expect the position to be added to the jumplist (these are jumps after all).

Patch adds the position to the jumplist using [the special `'` mark](https://neovim.io/doc/user/motion.html#m').  A better patch would instead use `vim.lsp.util.jump_to_location` in `common_sink` as this would prevent discrepencies from occuring in future, however this would require quite a significant refactor.