### PR TITLE
fix: call hierarchy params

### DIFF
--- a/lua/fzf_lsp.lua
+++ b/lua/fzf_lsp.lua
@@ -436,7 +436,7 @@ local function fzf_locations(bang, header, prompt, source, infile)
     )
   end
 
-  local options = { 
+  local options = {
     "--ansi",
     "--multi",
     "--bind",
@@ -745,7 +745,12 @@ function M.incoming_calls(bang, opts)
     return
   end
 
-  local params = vim.lsp.util.make_position_params()
+  local params = {
+    item = {
+      uri = vim.lsp.util.make_text_document_params().uri,
+      range = vim.lsp.util.make_range_params(0, "utf-8").range,
+    }
+  }
   call_sync(
     "callHierarchy/incomingCalls", params, opts, partial(incoming_calls_handler, bang)
   )
@@ -756,7 +761,12 @@ function M.outgoing_calls(bang, opts)
     return
   end
 
-  local params = vim.lsp.util.make_position_params()
+  local params = {
+    item = {
+      uri = vim.lsp.util.make_text_document_params().uri,
+      range = vim.lsp.util.make_range_params(0, "utf-8").range,
+    }
+  }
   call_sync(
     "callHierarchy/outgoingCalls", params, opts, partial(outgoing_calls_handler, bang)
   )


### PR DESCRIPTION
Update `incomingCalls` and `outgoingCalls` params to what seems to be the expected format, according to:

* [Language server protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchyItem)
* [Gopls documentation](https://pkg.go.dev/go.lsp.dev/protocol#CallHierarchyItem)

Unknowns:

* is it ok to assume `utf-8` when calling `make_range_params`? If not, how should we infer the encoding? (We shouldn't just not pass any arguments as this causes a warning log in recent nvim versions)
* I've only tested this with gopls (it didn't work before, it works now) and typescript-language-server (seems broken in both cases, I haven't dived deeper)

Fixes https://github.com/gfanto/fzf-lsp.nvim/issues/27.

